### PR TITLE
use include_tasks instead of deprecated include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_os_family == 'Debian'
 
-- include: configs.yml
+- include_tasks: configs.yml
 
-- include: configsipv6.yml
+- include_tasks: configsipv6.yml
   when: shorewall6_configs != False


### PR DESCRIPTION
Fixes the following error:
openstack.builder: ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.